### PR TITLE
add i18n support

### DIFF
--- a/src/exercise_ui/client/i18n.cljs
+++ b/src/exercise_ui/client/i18n.cljs
@@ -1,0 +1,21 @@
+(ns exercise-ui.client.i18n
+  (:require [reagent.core :as r]))
+
+(def languages 
+  {:en-US "English" 
+   :pt-BR "Português do Brasil"})
+
+(defonce language 
+  (r/atom (or (keyword (.getItem js/localStorage "language"))
+              (->> js/navigator.languages
+                   (map keyword)
+                   (filter languages)
+                   first)
+              :en-US)))
+
+(defn set-language! [lang] 
+  (.setItem js/localStorage "language" (name lang))
+  (reset! language lang))
+
+(defn value [i18n-map]
+  (get i18n-map @language i18n-map))

--- a/src/exercise_ui/client/ui/app.cljs
+++ b/src/exercise_ui/client/ui/app.cljs
@@ -1,8 +1,10 @@
 (ns exercise-ui.client.ui.app
   (:require
-    [bloom.commons.pages :refer [path-for ]]
-    [re-frame.core :refer [subscribe]]
-    [exercise-ui.client.pages :as pages]))
+   [bloom.commons.fontawesome :as fa]
+   [bloom.commons.pages :refer [path-for]]
+   [exercise-ui.client.i18n :as i18n]
+   [exercise-ui.client.pages :as pages]
+   [re-frame.core :refer [subscribe]]))
 
 (defonce favicon
  (let [element (.createElement js/document "link")]
@@ -11,14 +13,26 @@
    (.appendChild (.querySelector js/document "head") element)
    nil))
 
+(defn language-picker-view []
+  [:div {:tw "flex items-center gap-2"}
+   [fa/fa-language-solid {:tw "w-6 h-6 text-light"}]
+   [:select
+    {:tw "p-1"
+     :on-change (fn [e] (i18n/set-language! (-> e .-target .-value keyword)))}
+    (for [[lang-code lang-name] i18n/languages]
+      [:option {:value (name lang-code)
+                :selected (= lang-code @i18n/language)}
+       lang-name])]])
+
 (defn header-view []
-  [:div.header {:tw "font-header bg-accent"}
+  [:div.header {:tw "font-header bg-accent flex justify-between"}
    [:nav
     [:a {:tw "inline-flex items-center gap-2 p-2 text-light hover:bg-accent-light"
          :href (path-for [:exercises])}
      [:img {:src "/logomark.svg"
             :tw "w-6 h-6"}]
-     "clojure camp exercises"]]])
+     "clojure camp exercises"]]
+   [language-picker-view]])
 
 (defn main-view []
   [:div

--- a/src/exercise_ui/client/ui/pages/exercise.cljs
+++ b/src/exercise_ui/client/ui/pages/exercise.cljs
@@ -8,14 +8,15 @@
     [exercise-ui.client.ui.styles :as styles]
     [exercise-ui.utils :refer [parse-backticks]]
     [exercise-ui.client.ui.partials.code-view :refer [code-view format-code]]
-    [exercise-ui.client.ui.partials.teachable :refer [teachable-view]]))
+    [exercise-ui.client.ui.partials.teachable :refer [teachable-view]]
+    [exercise-ui.client.i18n :as i18n]))
 
 (defn solution-view [exercise]
   (r/with-let [open? (r/atom false)]
     [:section.solution
      [:header {:on-click (fn []
                            (swap! open? not))}
-      [:h2 "example solution"]
+      [:h2 (i18n/value {:en-US "example solution" :pt-BR "solução exemplo" })]
       (if @open?
         [fa/fa-chevron-down-solid]
         [fa/fa-chevron-right-solid])]
@@ -27,7 +28,7 @@
   (r/with-let [active-mode (r/atom :mode/table)]
     [:section.test-cases
      [:header {:tw "gap-2"}
-      [:h2 {:tw "grow"} "sample tests"]
+      [:h2 {:tw "grow"} (i18n/value {:en-US "sample tests" :pt-BR "testes de exemplo"})]
       (doall
         (for [[mode icon] [[:mode/table [fa/fa-table-solid]]
                            [:mode/rcf "RCF"]
@@ -95,12 +96,12 @@
   (when-let [exercise @(subscribe [:exercise exercise-id])]
     [:div.page.exercise
      [:header
-      [:h1 (exercise :title)]]
+      [:h1 (i18n/value (exercise :title))]]
 
      [:<>
       [:section.instructions
        (into [:<>]
-             (for [node (exercise :instructions)]
+             (for [node (i18n/value (exercise :instructions))]
                (if (or (not (string? node))
                        (and
                          (string/starts-with? node "(")
@@ -112,7 +113,7 @@
        (when (:function-template exercise)
          [:section.starter-code
           [:header
-           [:h2 "starter code"]]
+           [:h2 (i18n/value {:en-US "starter code" :pt-BR "código inicial"})]]
           [:div.body
            [code-view {:class "code"}
             (:function-template exercise)]]])
@@ -123,7 +124,7 @@
         (when (seq fns)
           [:section.functions
            [:header
-            [:h2 "related functions"]]
+            [:h2 (i18n/value {:en-US "related functions" :pt-BR "funções relacionadas"})]]
            [:div.body
             (into [:<>]
                   (->> fns
@@ -137,7 +138,7 @@
 
       (when (exercise :related)
         [:div.related
-         [:h2 "See also:"]
+         [:h2 (i18n/value {:en-US "See also:" :pt-BR "Veja também:"})]
          [:div.exercises
           (for [id (exercise :related)]
             ^{:key id}

--- a/src/exercise_ui/client/ui/pages/exercises.cljs
+++ b/src/exercise_ui/client/ui/pages/exercises.cljs
@@ -1,9 +1,10 @@
 (ns exercise-ui.client.ui.pages.exercises
   (:require
-    [clojure.set :as set]
-    [bloom.commons.pages :refer [path-for]]
-    [re-frame.core :refer [subscribe]]
-    [exercise-ui.client.ui.partials.teachable :refer [teachable-view]]))
+   [bloom.commons.pages :refer [path-for]]
+   [clojure.set :as set]
+   [exercise-ui.client.i18n :as i18n]
+   [exercise-ui.client.ui.partials.teachable :refer [teachable-view]]
+   [re-frame.core :refer [subscribe]]))
 
 (def difficulty->n {:low 1 :mid 2 :high 3})
 
@@ -59,7 +60,7 @@
 (defn sort-exercises
   [exercises]
   (->> exercises
-      (sort-by :title)
+      (sort-by (comp i18n/value :title))
       (sort-by (comp difficulty->n :difficulty))
       group-dependencies
       (sort-by (comp count :dependencies))
@@ -83,7 +84,7 @@
          [:td {:tw "p-1"}
           [:a {:tw "font-bold color-accent hover:underline visited:color-accent-extralight"
                :href (path-for [:exercise {:exercise-id (exercise :id)}])}
-           (exercise :title)]]
+           (i18n/value (exercise :title))]]
          [:td {:tw "p-1 opacity-25"}
           (into [:<>]
                 (interpose " " (map teachable-view (exercise :teaches))))]
@@ -97,7 +98,7 @@
   (let [grouped-exercises (group-by :category @(subscribe [:unordered-exercises]))]
     [:div.page.exercises
      [:table {:tw "border-collapse"}
-      [exercises-view "First Steps" @(subscribe [:ordered-exercises])]
-      [exercises-view "Exploring Functions" (sort-exercises (:learning-functions grouped-exercises))]
-      [exercises-view "More Practice" (sort-exercises (:starter grouped-exercises))]
-      [exercises-view "Putting Things Together" (sort-exercises (:synthesis grouped-exercises))]]]))
+      [exercises-view (i18n/value {:en-US "First Steps" :pt-BR "Primeiros Passos"}) @(subscribe [:ordered-exercises])]
+      [exercises-view (i18n/value {:en-US "Exploring Functions" :pt-BR "Explorando Funções"}) (sort-exercises (:learning-functions grouped-exercises))]
+      [exercises-view (i18n/value {:en-US "More Practice" :pt-BR "Mais Prática"}) (sort-exercises (:starter grouped-exercises))]
+      [exercises-view (i18n/value {:en-US "Putting Things Together" :pt-BR "Combinando Conceitos"}) (sort-exercises (:synthesis grouped-exercises))]]]))


### PR DESCRIPTION
Add i18n support, starting with pt-BR.

This PR:

- Create `i18n ns`.
- Add dropdown to select language.
- The language is choose following the order: localStorage > browser language > default language (`en-US`).
- Translated all titles.

This PR does not cover the translation of exercises name or instructions, will be done in the [exercises repo](https://github.com/clojure-camp/exercises) in a future PR.

Page with titles translated to pt-BR:
<img width="1728" alt="Screenshot 2024-11-12 at 06 27 06" src="https://github.com/user-attachments/assets/9c202f89-522e-4b63-a8fe-f9e97ed07267">
