### PR TITLE
Fix default value when missing translation

### DIFF
--- a/src/exercise_ui/client/i18n.cljs
+++ b/src/exercise_ui/client/i18n.cljs
@@ -18,4 +18,4 @@
   (reset! language lang))
 
 (defn value [i18n-map]
-  (get i18n-map @language i18n-map))
+  (get i18n-map @language (:en-US i18n-map)))


### PR DESCRIPTION
Fixes #4 

Changed the default value on i18n to get `:en-US` as default value

ASAP I'll translate the new exercises to `pt-BR` 😇 